### PR TITLE
Fixes `A non-numeric value encountered` in PhpMath.php

### DIFF
--- a/library/Zend/Locale/Math/PhpMath.php
+++ b/library/Zend/Locale/Math/PhpMath.php
@@ -92,6 +92,9 @@ class Zend_Locale_Math_PhpMath extends Zend_Locale_Math
         if (empty($op1)) {
             $op1 = 0;
         }
+        if (empty($op2)) {
+            $op2 = 0;
+        }
         $op1  = self::normalize($op1);
         $op2  = self::normalize($op2);
         $result = $op1 - $op2;


### PR DESCRIPTION
See https://github.com/OpenMage/magento-lts/issues/3751

Same change has been applied to `public static function Add($op1, $op2, $scale = null)` in https://github.com/Shardj/zf1-future/commit/5114684a7c2dc7eba32d8c8dc6fb9450d3da9e5f